### PR TITLE
Enable page editing by slug

### DIFF
--- a/api/get_page.php
+++ b/api/get_page.php
@@ -24,17 +24,19 @@ $stmt->bindValue(':slug', $slug, SQLITE3_TEXT);
 $result = $stmt->execute();
 
 if ($row = $result->fetchArray(SQLITE3_ASSOC)) {
-    echo json_encode([
+    echo json_encode(array_merge([
+        'success' => true
+    ], [
         'title' => $row['title'],
         'slug' => $row['slug'],
         'description' => $row['description'],
         'keywords' => $row['keywords'],
         'language' => $row['language'],
         'content' => $row['content']
-    ]);
+    ]));
 } else {
     http_response_code(404);
-    echo json_encode(['error' => 'Page not found']);
+    echo json_encode(['success' => false, 'error' => 'Page not found']);
 }
 
 $db->close();

--- a/api/save_page.php
+++ b/api/save_page.php
@@ -2,22 +2,22 @@
 header('Content-Type: application/json');
 
 $data = json_decode(file_get_contents('php://input'), true);
-if (!$data || !isset($data['page_id']) || !isset($data['content'])) {
+if (!$data || !isset($data['slug']) || !isset($data['content'])) {
     http_response_code(400);
-    echo json_encode(['error' => 'Invalid input: missing page_id or content']);
+    echo json_encode(['error' => 'Invalid input: missing slug or content']);
     exit;
 }
 
-$pageId = intval($data['page_id']);
+$slug = $data['slug'];
 $content = $data['content'];
 
 try {
     $db = new SQLite3(__DIR__ . '/../db/database.db');
 
-    $stmt = $db->prepare("UPDATE pages SET content = :content, updated_at = :updated_at WHERE id = :id");
+    $stmt = $db->prepare("UPDATE pages SET content = :content, updated_at = :updated_at WHERE slug = :slug");
     $stmt->bindValue(':content', $content, SQLITE3_TEXT);
     $stmt->bindValue(':updated_at', date('c'), SQLITE3_TEXT);
-    $stmt->bindValue(':id', $pageId, SQLITE3_INTEGER);
+    $stmt->bindValue(':slug', $slug, SQLITE3_TEXT);
 
     $result = $stmt->execute();
 


### PR DESCRIPTION
## Summary
- return success flag when fetching pages
- update save API to work via slug instead of id

## Testing
- `php -l api/get_page.php`
- `php -l api/save_page.php`


------
https://chatgpt.com/codex/tasks/task_e_68407afd32d08322b20bd9b53dd5f497